### PR TITLE
重构项目模块路径和更新依赖镜像

### DIFF
--- a/example/dev/docker-compose.yaml
+++ b/example/dev/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
         ipv4_address: 192.168.66.12
   freeswitch:
     restart: always
-    image: lightcall/freeswitch
+    image: ghcr.io/tcmzzz/freeswitch:v1.10.9
     volumes:
       - ./run/fs-cdr-csv:/usr/local/freeswitch/log/cdr-csv
       - ./run/fs-record:/usr/local/freeswitch/recordings

--- a/example/dev/fake-privider/Dockerfile
+++ b/example/dev/fake-privider/Dockerfile
@@ -1,5 +1,6 @@
-FROM lightcall/freeswitch
+FROM ghcr.io/tcmzzz/freeswitch:v1.10.9
 
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
 RUN apt-get -yq install rsync
 
 RUN rm -rf /usr/local/freeswitch/scripts/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module lightcall
+module github.com/tcmzzz/lightcall
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/nxadm/tail v1.4.11

--- a/server/appender/activity/activity.go
+++ b/server/appender/activity/activity.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"lightcall/server/appender"
+	"github.com/tcmzzz/lightcall/server/appender"
 
 	"github.com/pkg/errors"
 	"github.com/pocketbase/pocketbase/core"

--- a/server/appender/change/change.go
+++ b/server/appender/change/change.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"lightcall/server/appender"
+	"github.com/tcmzzz/lightcall/server/appender"
 
 	"github.com/pkg/errors"
 	"github.com/pocketbase/pocketbase/core"

--- a/server/call/handler.go
+++ b/server/call/handler.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	precall "lightcall/server/cloud/precall"
-	"lightcall/server/config"
+	precall "github.com/tcmzzz/lightcall/server/cloud/precall"
+	"github.com/tcmzzz/lightcall/server/config"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"

--- a/server/cloud/mock/mock.go
+++ b/server/cloud/mock/mock.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"lightcall/server/cloud/precall"
+	"github.com/tcmzzz/lightcall/server/cloud/precall"
 
 	"github.com/pocketbase/pocketbase/core"
 )

--- a/server/cloud/precall/precall.go
+++ b/server/cloud/precall/precall.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"lightcall/server/config"
+	"github.com/tcmzzz/lightcall/server/config"
 
 	"github.com/pkg/errors"
 	"github.com/pocketbase/pocketbase/core"

--- a/server/hook.go
+++ b/server/hook.go
@@ -3,7 +3,7 @@ package server
 import (
 	"strings"
 
-	"lightcall/server/config"
+	"github.com/tcmzzz/lightcall/server/config"
 
 	"github.com/pocketbase/pocketbase/core"
 )

--- a/server/router.go
+++ b/server/router.go
@@ -1,10 +1,10 @@
 package server
 
 import (
-	"lightcall/server/call"
-	"lightcall/server/cloud/mock"
-	"lightcall/server/cloud/precall"
-	"lightcall/server/config"
+	"github.com/tcmzzz/lightcall/server/call"
+	"github.com/tcmzzz/lightcall/server/cloud/mock"
+	"github.com/tcmzzz/lightcall/server/cloud/precall"
+	"github.com/tcmzzz/lightcall/server/config"
 
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"

--- a/server/server.go
+++ b/server/server.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	"lightcall/server/appender"
-	"lightcall/server/appender/activity"
-	"lightcall/server/appender/change"
-	"lightcall/server/config"
-	"lightcall/server/tail"
-	"lightcall/server/tail/cdc"
-	"lightcall/server/tail/fs"
+	"github.com/tcmzzz/lightcall/server/appender"
+	"github.com/tcmzzz/lightcall/server/appender/activity"
+	"github.com/tcmzzz/lightcall/server/appender/change"
+	"github.com/tcmzzz/lightcall/server/config"
+	"github.com/tcmzzz/lightcall/server/tail"
+	"github.com/tcmzzz/lightcall/server/tail/cdc"
+	"github.com/tcmzzz/lightcall/server/tail/fs"
 
 	"github.com/pocketbase/pocketbase/core"
 )

--- a/sql/app/9999999999_dev_import.go
+++ b/sql/app/9999999999_dev_import.go
@@ -4,5 +4,5 @@
 package app
 
 import (
-	_ "lightcall/example/dev/data"
+	_ "github.com/tcmzzz/lightcall/example/dev/data"
 )


### PR DESCRIPTION
## Summary
- 将项目模块路径从 lightcall 调整为 github.com/tcmzzz/lightcall
- 更新了所有相关的 import 语句
- 更新了 docker-compose.yaml 和 Dockerfile 中的镜像地址

## Test plan
- [x] 代码编译通过
- [x] lint 检查通过
- [ ] 需要验证功能是否正常

🤖 Generated with [Claude Code](https://claude.ai/code)