### PR TITLE
Fix Docker build issue by specifying main.go file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ RUN pnpm install
 RUN pnpm build
 
 FROM golang:1.25-alpine AS backend-builder
+
+ADD go.mod go.sum /
+RUN go mod download
+
 WORKDIR /app
-COPY ./ .
-RUN CGO_ENABLED=0 go build -o lightcall ./cmd/lightcall
+COPY . .
+RUN CGO_ENABLED=0 go build -o lightcall ./cmd/lightcall/main.go
 
 FROM alpine:latest
 ENV TZ=Asia/Shanghai


### PR DESCRIPTION
This PR fixes the Docker build issue in GitHub Actions by specifying the correct file path for the Go build command. The previous build was failing with 'stat /app/cmd/lightcall: directory not found' error.