### PR TITLE
完善生产环境部署文档和配置说明

### DIFF
--- a/example/prod/README.md
+++ b/example/prod/README.md
@@ -1,0 +1,44 @@
+# 生产环境部署指南
+
+## 设置环境变量
+
+在启动服务之前，需要设置管理员邮箱环境变量：
+
+```bash
+export INIT_ADMIN_EMAIL=admin@yourdomain.com
+```
+
+## 启动服务
+
+使用docker compose启动生产环境服务：
+
+```bash
+docker compose up -d
+```
+
+## 获取管理员密码
+
+服务启动后，系统会自动生成管理员账户和密码。可以通过以下命令查看：
+
+```bash
+docker compose logs | grep "Superuser created successfully"
+```
+
+或者：
+
+```bash
+docker compose logs backend | grep "Superuser created successfully"
+```
+
+你将看到类似以下的输出：
+```
+Superuser created successfully, username: admin@yourdomain.com, password: generated_password
+```
+
+请保存好这个密码，用于首次登录系统。
+
+## 注意事项
+
+1. 请确保设置的INIT_ADMIN_EMAIL环境变量是有效的邮箱地址
+2. 生成的密码是随机的，请妥善保管
+3. 首次登录后请立即修改默认密码

--- a/example/prod/README.md
+++ b/example/prod/README.md
@@ -1,12 +1,11 @@
-# 生产环境部署指南
-
 ## 设置环境变量
 
-在启动服务之前，需要设置管理员邮箱环境变量：
+在启动服务之前，需要:
 
-```bash
-export INIT_ADMIN_EMAIL=admin@yourdomain.com
-```
+1. 在`docker-compose.yaml` 里设置管理员邮箱环境变量 `INIT_ADMIN_EMAIL`
+2. 配置证书. 修改`Caddyfile`, 解析域名至Caddy服务器让其自动获取证书, 或者配置已有的证书
+3. `docker-compose.yaml` 中 模拟运营商的配置 仅用于演示, 不需要可以去掉
+
 
 ## 启动服务
 
@@ -21,14 +20,9 @@ docker compose up -d
 服务启动后，系统会自动生成管理员账户和密码。可以通过以下命令查看：
 
 ```bash
-docker compose logs | grep "Superuser created successfully"
+docker compose logs | grep "password"
 ```
 
-或者：
-
-```bash
-docker compose logs backend | grep "Superuser created successfully"
-```
 
 你将看到类似以下的输出：
 ```

--- a/example/prod/docker-compose.yaml
+++ b/example/prod/docker-compose.yaml
@@ -36,7 +36,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-  fakeprovider: # 模拟运营商响应, 生产环境可去掉
+  # 模拟运营商 BEGIN. 仅用于演示, 生产环境去掉
+  fakeprovider:
     restart: always
     build:
       context: ../dev/fake-privider
@@ -54,3 +55,4 @@ networks:
       config:
         - subnet: "192.168.66.0/24"
           gateway: "192.168.66.1"
+  # 模拟运营商 END. 仅用于演示, 生产环境去掉


### PR DESCRIPTION
此PR完善了生产环境部署的相关文档和配置说明：
- 更新README.md，详细说明环境变量设置、证书配置和模拟运营商配置的移除
- 修改docker-compose.yaml，添加注释说明模拟运营商配置仅用于演示
- 优化密码获取命令说明